### PR TITLE
replaced peripherals page link to wiki

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -17,4 +17,6 @@ From here, you can refer to various documents download softwares about CHIRIMEN.
 
 ## [Repository](http://github.com/chirimen-oh)
 
-## [Peripherals for CHIRIMEN Board computer](peripherals.html)
+## [Peripherals for CHIRIMEN Board computer](https://github.com/chirimen-oh/chirimen-oh.github.io/wiki/peripherals(en))
+
+## [Parts for CHIRIMEN Board computer](https://github.com/chirimen-oh/chirimen-oh.github.io/wiki/parts(en))

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -17,7 +17,9 @@ title: Index Page
 
 ## [リポジトリ](http://github.com/chirimen-oh)
 
-## [CHIRIMENボードコンピュータに接続可能な周辺機器情報](peripherals.html)
+## [CHIRIMENボードコンピュータに接続可能な周辺機器情報](https://github.com/chirimen-oh/chirimen-oh.github.io/wiki/peripherals(ja))
+
+## [CHIRIMENボードコンピュータに接続可能なパーツ情報](https://github.com/chirimen-oh/chirimen-oh.github.io/wiki/parts(ja))
 
 
 


### PR DESCRIPTION
Issue Fixed # 158, #159

## Proposed Changes

  - 周辺機器ページへのリンクを wikiに変更
