### PR TITLE
upgrade ruby to 2.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1
+  - 2.4
 
 install: gem install jekyll jekyll-paginate jemoji html-proofer
 script: jekyll serve --baseurl "" --detach && htmlproofer ./_site --disable-external --empty-alt-ignore


### PR DESCRIPTION
Issue Fixed #80 

Currently failed:
https://travis-ci.org/chirimen-oh/chirimen-oh.github.io/builds/341850396

To be success after upgrades ruby version to 2.4:
https://travis-ci.org/sizuhiko/chirimen-oh.github.io/builds/416677047