### PR TITLE
Add news contents and tutorial block

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -110,6 +110,12 @@ syntax-highlight: True
 
 events:
   - image: "/img/browser_300.png"
+    date: "October 10 2018"
+    description: "CHIRIMEN for Raspberry Pi 3 Ver.2018/10/10 released."
+  - image: "/img/browser_300.png"
+    date: "November 2 2017"
+    description: "CHIRIMEN for Raspberry Pi 3 released."
+  - image: "/img/browser_300.png"
     date: "March 1 2017"
     description: "New firmware had released."
   - image: "/img/browser_300.png"
@@ -187,6 +193,7 @@ pages_list:
   News: 'news'
   About: 'about'
   Documents/Downloads: 'documents'
+  Tutorial: 'tutorial'
   Blog: 'latest-post'
   Timeline: 'timeline'
   Contact: 'contact'

--- a/_config_local.yml
+++ b/_config_local.yml
@@ -110,6 +110,12 @@ syntax-highlight: True
 
 events:
   - image: "/img/browser_300.png"
+    date: "October 10 2018"
+    description: "CHIRIMEN for Raspberry Pi 3 Ver.2018/10/10 released."
+  - image: "/img/browser_300.png"
+    date: "November 2 2017"
+    description: "CHIRIMEN for Raspberry Pi 3 released."
+  - image: "/img/browser_300.png"
     date: "March 1 2017"
     description: "New firmware had released."
   - image: "/img/browser_300.png"
@@ -187,6 +193,7 @@ pages_list:
   News: 'news'
   About: 'about'
   Documents/Downloads: 'documents'
+  Tutorial: 'tutorial'
   Blog: 'latest-post'
   Timeline: 'timeline'
   Contact: 'contact'

--- a/_includes/tutorial.html
+++ b/_includes/tutorial.html
@@ -1,0 +1,12 @@
+
+<!-- Tutorial Start -->
+
+<section id="{{ page.section-type }}" class="container content-section text-center">
+  <div class="row">
+    <div class="col-md-10 col-md-offset-1">
+      {{ page.content | markdownify }}
+    </div>
+  </div>
+</section>
+
+<!-- Tutorial End -->

--- a/news.html
+++ b/news.html
@@ -13,7 +13,7 @@ Oct. 10, 2018 "CHIRIMEN for Raspberry Pi 3 Ver. 2018/10/10" released.
 The ["CHIRIMEN for Raspberry Pi 3 Ver. 2018/10/10"](https://github.com/chirimen-oh/chirimen-raspi3/releases/tag/20181010) is now publicly available! 
 Details refers `Change notes` on the [release page](https://github.com/chirimen-oh/chirimen-raspi3/releases/tag/20181010).
 
-2017.11.2 "CHIRIMEN for Raspberry Pi 3"リリース
+2018.10.10 "CHIRIMEN for Raspberry Pi 3 Ver. 2018/10/10"リリース
 
 この度、["CHIRIMEN for Raspberry Pi 3 Ver. 2018/10/10"](https://github.com/chirimen-oh/chirimen-raspi3/releases/tag/20181010) を公開いたしました。
 詳細は[リリースページ](https://github.com/chirimen-oh/chirimen-raspi3/releases/tag/20181010)の `Change notes` を参照してください。

--- a/news.html
+++ b/news.html
@@ -6,6 +6,20 @@ title: News
 
 ----
 
+## News 2018/10/10
+
+Oct. 10, 2018 "CHIRIMEN for Raspberry Pi 3 Ver. 2018/10/10" released. 
+
+The ["CHIRIMEN for Raspberry Pi 3 Ver. 2018/10/10"](https://github.com/chirimen-oh/chirimen-raspi3/releases/tag/20181010) is now publicly available! 
+Details refers `Change notes` on the [release page](https://github.com/chirimen-oh/chirimen-raspi3/releases/tag/20181010).
+
+2017.11.2 "CHIRIMEN for Raspberry Pi 3"リリース
+
+この度、["CHIRIMEN for Raspberry Pi 3 Ver. 2018/10/10"](https://github.com/chirimen-oh/chirimen-raspi3/releases/tag/20181010) を公開いたしました。
+詳細は[リリースページ](https://github.com/chirimen-oh/chirimen-raspi3/releases/tag/20181010)の `Change notes` を参照してください。
+
+----
+
 ## News 2017/11/02
 
 Nov. 2, 2017 "CHIRIMEN for Raspberry Pi 3" released. 

--- a/tutorial.html
+++ b/tutorial.html
@@ -1,0 +1,10 @@
+---
+layout: null
+section-type: about
+title: About
+---
+## Tutorial
+
+- [こちらから、CHIRIMEN for Raspberry Pi 3のチュートリアルを参照ください。](https://tutorial.chirimen.org/)
+- [More can be read in the CHIRIMEN for Raspberry Pi 3 tutorial.](https://tutorial.chirimen.org/)
+


### PR DESCRIPTION
Issue Fixed #84 

## Proposed Changes

  - チュートリアルメニューを追加
  - チュートリアルブロックからチュートリアルページへのリンクを追加
    - 英語と日本語のリンク先は同じになっています
  - Ver. 2018/10/10 のニュースリリースとタイムラインの追加
