### PR TITLE
Fix CI using bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/
 _deploy/*
 Rakefile
 .jekyll-metadata
+.ruby-version
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 rvm:
   - 2.4
 
-install: gem install jekyll jekyll-paginate jemoji html-proofer
-script: jekyll serve --baseurl "" --detach && htmlproofer ./_site --disable-external --empty-alt-ignore
+cache: bundler
+script: bundle exec jekyll serve --baseurl "" --detach && bundle exec htmlproofer ./_site --disable-external --empty-alt-ignore
 
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
+gem "html-proofer"

--- a/_config.yml
+++ b/_config.yml
@@ -200,7 +200,7 @@ pages_list:
 
 # Exclusion list from the generated _site
 
-exclude: ["LICENSE", "README.md", "CONTRIBUTING", "CONTRIBUTORS", "scripts"]
+exclude: ["LICENSE", "README.md", "CONTRIBUTING", "CONTRIBUTORS", "scripts", 'Gemfile','Gemfile.lock','Rakefile','vendor']
 
 # Pagination path
 

--- a/_config_local.yml
+++ b/_config_local.yml
@@ -200,7 +200,7 @@ pages_list:
 
 # Exclusion list from the generated _site
 
-exclude: ["LICENSE", "README.md", "CONTRIBUTING", "CONTRIBUTORS", "scripts"]
+exclude: ["LICENSE", "README.md", "CONTRIBUTING", "CONTRIBUTORS", "scripts", 'Gemfile','Gemfile.lock','Rakefile','vendor']
 
 # Pagination path
 


### PR DESCRIPTION
Gemfileが追加されて、CIが失敗する問題に対応

## Proposed Changes

  - Gemfile の `github-pages` でインストールされる `jekill` を利用してビルドを実行
  - `html-proofer` を Gemfile に追加してbundlerから実行するように変更
  - bundlerでインストールした内容をキャッシュするように変更
  - bundlerでインストールされるファイル群をビルドに利用しないように除外する
