### PR TITLE
ビルド設定の刷新

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -214,6 +214,6 @@ paginate_path: "blog/page:num/"
 sass:
   style: compressed
 
-gems:
+plugins:
   - jekyll-paginate
   - jemoji


### PR DESCRIPTION
ビルド・CIが失敗するので、以下のように修正しました:

非推奨のgemsの設定オプションをpluginsに変更
またビルド環境はCloudflare Pagesの最新のものに更新

- Build image v2
- Ruby 3.2.2

Build command

```
bundle exec jekyll build
```

Build output directory

```
/_site
```

Environment variables

```.env
LANG=en_US.UTF-8
LANGUAGE=en_US.UTF-8
LC_ALL=C.UTF-8
```

https://developers.cloudflare.com/pages/configuration/build-image/#supported-languages-and-tools

(thanks! @gurezo)